### PR TITLE
RTECO-1282: Fix ecosystem plugin dev builds — vendor repos, classloader conflicts, Java version mismatch

### DIFF
--- a/Jenkinsfile-dev-build
+++ b/Jenkinsfile-dev-build
@@ -79,6 +79,7 @@ node("docker-ubuntu24-xlarge") {
             stage('Initial Setup'){
                 try  {
                 script{
+                     echo ">>> RUNNING FROM BRANCH: RTECO-1282-gradle-buildscript-repo21-init <<<"
                      installJfrogCli()
                      selectPlugins()
                      sh 'apt-get update -y && apt-get install -y unzip'

--- a/Jenkinsfile-dev-build
+++ b/Jenkinsfile-dev-build
@@ -91,6 +91,43 @@ node("docker-ubuntu24-xlarge") {
 
                      configGradle()
 
+                     withCredentials([
+                         usernamePassword(credentialsId: 'repo21', usernameVariable: 'REPO21_USER', passwordVariable: 'REPO21_PASSWORD'),
+                         string(credentialsId: 'repo21-url', variable: 'REPO21_URL')
+                     ]) {
+                         sh "mkdir -p '${gradleHomePath}/init.d'"
+                         writeFile(
+                             file: "${gradleHomePath}/init.d/repo21-buildscript.gradle",
+                             text: """
+def repo21Url = "\${REPO21_URL}/artifactory/dev-master-maven-virtual"
+def repo21User = "\${REPO21_USER}"
+def repo21Pass = "\${REPO21_PASSWORD}"
+
+allprojects {
+    buildscript {
+        repositories {
+            maven {
+                url repo21Url
+                credentials { username repo21User; password repo21Pass }
+            }
+        }
+    }
+}
+
+beforeSettings { settings ->
+    settings.pluginManagement {
+        repositories {
+            maven {
+                url repo21Url
+                credentials { username repo21User; password repo21Pass }
+            }
+        }
+    }
+}
+"""
+                         )
+                     }
+
                      jdk8Path = installJdkFromArchive('8')
 
                      jdk17Path = installJdkFromArchive('17')
@@ -205,46 +242,6 @@ def createBuildTasks(Map reposMap, String pluginSelected, String mvnHome, String
 
 def configGradle(){
     sh "${builderPath} gradlec --server-id-resolve=repo21 --repo-resolve=dev-master-maven-virtual"
-    withCredentials([
-        usernamePassword(credentialsId: 'repo21', usernameVariable: 'REPO21_USER', passwordVariable: 'REPO21_PASSWORD'),
-        string(credentialsId: 'repo21-url', variable: 'REPO21_URL')
-    ]) {
-        // Gradle's jf-gradlec routing doesn't intercept buildscript{} classpath or
-        // pluginManagement{} repos — those hit Maven Central/Plugin Portal directly and
-        // get 429s under parallel load. This init script adds repo21 as the first
-        // candidate for both so Gradle finds cached artifacts there before going upstream.
-        sh "mkdir -p '${gradleHomePath}/init.d'"
-        writeFile(
-            file: "${gradleHomePath}/init.d/repo21-buildscript.gradle",
-            text: """
-def repo21Url = "${REPO21_URL}/artifactory/dev-master-maven-virtual"
-def repo21User = "${REPO21_USER}"
-def repo21Pass = "${REPO21_PASSWORD}"
-
-allprojects {
-    buildscript {
-        repositories {
-            maven {
-                url repo21Url
-                credentials { username repo21User; password repo21Pass }
-            }
-        }
-    }
-}
-
-beforeSettings { settings ->
-    settings.pluginManagement {
-        repositories {
-            maven {
-                url repo21Url
-                credentials { username repo21User; password repo21Pass }
-            }
-        }
-    }
-}
-"""
-        )
-    }
 }
 
 def formatStatusMatrix(Map matrix) {

--- a/Jenkinsfile-dev-build
+++ b/Jenkinsfile-dev-build
@@ -205,6 +205,46 @@ def createBuildTasks(Map reposMap, String pluginSelected, String mvnHome, String
 
 def configGradle(){
     sh "${builderPath} gradlec --server-id-resolve=repo21 --repo-resolve=dev-master-maven-virtual"
+    withCredentials([
+        usernamePassword(credentialsId: 'repo21', usernameVariable: 'REPO21_USER', passwordVariable: 'REPO21_PASSWORD'),
+        string(credentialsId: 'repo21-url', variable: 'REPO21_URL')
+    ]) {
+        // Gradle's jf-gradlec routing doesn't intercept buildscript{} classpath or
+        // pluginManagement{} repos — those hit Maven Central/Plugin Portal directly and
+        // get 429s under parallel load. This init script adds repo21 as the first
+        // candidate for both so Gradle finds cached artifacts there before going upstream.
+        sh "mkdir -p '${gradleHomePath}/init.d'"
+        writeFile(
+            file: "${gradleHomePath}/init.d/repo21-buildscript.gradle",
+            text: """
+def repo21Url = "${REPO21_URL}/artifactory/dev-master-maven-virtual"
+def repo21User = "${REPO21_USER}"
+def repo21Pass = "${REPO21_PASSWORD}"
+
+allprojects {
+    buildscript {
+        repositories {
+            maven {
+                url repo21Url
+                credentials { username repo21User; password repo21Pass }
+            }
+        }
+    }
+}
+
+beforeSettings { settings ->
+    settings.pluginManagement {
+        repositories {
+            maven {
+                url repo21Url
+                credentials { username repo21User; password repo21Pass }
+            }
+        }
+    }
+}
+"""
+        )
+    }
 }
 
 def formatStatusMatrix(Map matrix) {

--- a/Jenkinsfile-dev-build
+++ b/Jenkinsfile-dev-build
@@ -79,7 +79,6 @@ node("docker-ubuntu24-xlarge") {
             stage('Initial Setup'){
                 try  {
                 script{
-                     echo ">>> RUNNING FROM BRANCH: RTECO-1282-gradle-buildscript-repo21-init <<<"
                      installJfrogCli()
                      selectPlugins()
                      sh 'apt-get update -y && apt-get install -y unzip'
@@ -91,43 +90,6 @@ node("docker-ubuntu24-xlarge") {
                      configRepo21()
 
                      configGradle()
-
-                     withCredentials([
-                         usernamePassword(credentialsId: 'repo21', usernameVariable: 'REPO21_USER', passwordVariable: 'REPO21_PASSWORD'),
-                         string(credentialsId: 'repo21-url', variable: 'REPO21_URL')
-                     ]) {
-                         sh "mkdir -p '${gradleHomePath}/init.d'"
-                         writeFile(
-                             file: "${gradleHomePath}/init.d/repo21-buildscript.gradle",
-                             text: """
-def repo21Url = "\${REPO21_URL}/artifactory/dev-master-maven-virtual"
-def repo21User = "\${REPO21_USER}"
-def repo21Pass = "\${REPO21_PASSWORD}"
-
-allprojects {
-    buildscript {
-        repositories {
-            maven {
-                url repo21Url
-                credentials { username repo21User; password repo21Pass }
-            }
-        }
-    }
-}
-
-beforeSettings { settings ->
-    settings.pluginManagement {
-        repositories {
-            maven {
-                url repo21Url
-                credentials { username repo21User; password repo21Pass }
-            }
-        }
-    }
-}
-"""
-                         )
-                     }
 
                      jdk8Path = installJdkFromArchive('8')
 

--- a/Jenkinsfile-dev-build
+++ b/Jenkinsfile-dev-build
@@ -483,11 +483,14 @@ def executeGradle(repoName, details){
         sh "pwd"
         sh "ls -la"
 
-        // build-info-extractor and artifactory-client-java both declare com.jfrog.artifactory
-        // in their own buildscript{} block. jf gradle injects a different version of the same
-        // plugin as an init-script dependency, producing a classloader conflict. Use the
-        // project's own Gradle wrapper for these two so only one version is ever loaded.
-        def useRawGradlew = repoName in ['build-info-extractor', 'artifactory-client-java']
+        // Three projects cannot use jf gradle:
+        // - build-info-extractor, artifactory-client-java: classloader conflict — they apply
+        //   com.jfrog.artifactory themselves and jf gradle injects a different version via
+        //   init script, causing "Cannot cast ArtifactoryPluginConvention to itself".
+        // - jfrog-testing-infra: runs with JDK 8, but the build-info-extractor-gradle uber JAR
+        //   injected by jf gradle is compiled with Java 17 (class file major version 61).
+        // For all three, use the project's own ./gradlew so only one plugin version is loaded.
+        def useRawGradlew = repoName in ['build-info-extractor', 'artifactory-client-java', 'jfrog-testing-infra']
 
         if (!useRawGradlew) {
             // jf gradle requires a per-project .jfrog/projects/gradle.yaml. Always run gradlec

--- a/Jenkinsfile-dev-build
+++ b/Jenkinsfile-dev-build
@@ -37,17 +37,17 @@ node("docker-ubuntu24-xlarge") {
             env.REPO_NAME_21 = "$repo21Name"
         }
         def reposMap = [
-            "artifactory-jenkins-plugin": [url: "https://github.com/jfrog/jenkins-artifactory-plugin", branch:"master", type: "maven", jdk:"8"],
+            "artifactory-jenkins-plugin": [url: "https://github.com/jfrog/jenkins-artifactory-plugin", branch:"master", type: "maven", jdk:"8", resolveRepo: "ecosys-jenkins-repos"],
             "build-info-extractor": [url: "https://github.com/jfrog/build-info", branch: "master", type: "gradle", buildDir:"build/libs", jdk:"8"],
-            "teamcity-artifactory-plugin": [url: "https://github.com/jfrog/teamcity-artifactory-plugin.git", branch: "master",  type: "maven", jdk:"17"],
+            "teamcity-artifactory-plugin": [url: "https://github.com/jfrog/teamcity-artifactory-plugin.git", branch: "master",  type: "maven", jdk:"17", resolveRepo: "ecosys-teamcity-repos"],
             "artifactory-maven-plugin": [url: "https://github.com/jfrog/artifactory-maven-plugin.git", branch: "master", type: "maven", jdk:"8"],
             "artifactory-client-java": [url: "https://github.com/jfrog/artifactory-client-java.git", branch: "master", type: "gradle", buildDir:"services/build/libs", "jdk":"8"],
             "artifactory-gradle-plugin": [url: "https://github.com/jfrog/artifactory-gradle-plugin.git", branch: "main", type: "gradle", buildDir:"build/libs", hasFunctionalTest:true, jdk:"8"],
             "file-specs-java": [url: "https://github.com/jfrog/file-specs-java.git", branch: "main", type: "gradle", buildDir:"build/libs", jdk:"8"],
             "jfrog-testing-infra": [url: "https://github.com/jfrog/jfrog-testing-infra.git", branch: "main", dir:"java", type: "gradle", buildDir:"build/libs", jdk:"8"],
-            "bamboo-artifactory-plugin": [url: "https://github.com/jfrog/bamboo-artifactory-plugin.git", branch: "master", type: "maven", jdk:"11"],
-            "jenkins-jfrog-plugin": [url: "https://github.com/jenkinsci/jfrog-plugin.git", branch:"main", type: "maven", jdk:"11"],
-            "bamboo-jfrog-plugin": [url: "https://github.com/jfrog/bamboo-jfrog-plugin.git", branch: "main", type: "maven", jdk:"17"],
+            "bamboo-artifactory-plugin": [url: "https://github.com/jfrog/bamboo-artifactory-plugin.git", branch: "master", type: "maven", jdk:"11", resolveRepo: "ecosys-bamboo-repos"],
+            "jenkins-jfrog-plugin": [url: "https://github.com/jenkinsci/jfrog-plugin.git", branch:"main", type: "maven", jdk:"11", resolveRepo: "ecosys-jenkins-repos"],
+            "bamboo-jfrog-plugin": [url: "https://github.com/jfrog/bamboo-jfrog-plugin.git", branch: "main", type: "maven", jdk:"17", resolveRepo: "ecosys-bamboo-repos"],
             "jfrog-azure-devops-extension": [url: "https://github.com/jfrog/jfrog-azure-devops-extension.git",branch: "dev", type: "npm"]
         ]
 
@@ -384,7 +384,8 @@ def executeMaven(repoName, details){
             echo "Cloning from ${details.url}..."
             git url: details.url, branch: details.branch
 
-            sh "${builderPath} mvnc --server-id-resolve=repo21 --repo-resolve-releases=dev-master-maven-virtual --repo-resolve-snapshots=dev-master-maven-virtual"
+            def resolveRepo = details.resolveRepo ?: 'dev-master-maven-virtual'
+            sh "${builderPath} mvnc --server-id-resolve=repo21 --repo-resolve-releases=${resolveRepo} --repo-resolve-snapshots=${resolveRepo}"
             sh "${builderPath} mvn clean install -DskipTests"
 
             sh "mkdir -p ${tempScanDir}"

--- a/Jenkinsfile-dev-build
+++ b/Jenkinsfile-dev-build
@@ -484,20 +484,19 @@ def executeGradle(repoName, details){
         sh "pwd"
         sh "ls -la"
 
-        // Three projects cannot use jf gradle:
+        // Always run gradlec so jf audit has a valid server config (gradle.yaml).
+        // Some repos ship their own gradle.yaml with a different serverID that jf audit
+        // would otherwise pick up and fail on.
+        sh "${builderPath} gradlec --server-id-resolve=repo21 --repo-resolve=dev-master-maven-virtual --use-wrapper"
+
+        // Three projects cannot use jf gradle for the BUILD step:
         // - build-info-extractor, artifactory-client-java: classloader conflict — they apply
         //   com.jfrog.artifactory themselves and jf gradle injects a different version via
         //   init script, causing "Cannot cast ArtifactoryPluginConvention to itself".
         // - jfrog-testing-infra: runs with JDK 8, but the build-info-extractor-gradle uber JAR
         //   injected by jf gradle is compiled with Java 17 (class file major version 61).
-        // For all three, use the project's own ./gradlew so only one plugin version is loaded.
+        // gradlec above is safe for all three; only jf gradle triggers the conflict.
         def useRawGradlew = repoName in ['build-info-extractor', 'artifactory-client-java', 'jfrog-testing-infra']
-
-        if (!useRawGradlew) {
-            // jf gradle requires a per-project .jfrog/projects/gradle.yaml. Always run gradlec
-            // here so `jf gradle ... --use-wrapper` can resolve through repo21.
-            sh "${builderPath} gradlec --server-id-resolve=repo21 --repo-resolve=dev-master-maven-virtual --use-wrapper"
-        }
 
         echo "Starting Gradle build for ${repoName}..."
 

--- a/Jenkinsfile-dev-build
+++ b/Jenkinsfile-dev-build
@@ -441,9 +441,10 @@ def UploadAndScanBinary(repoName, uploadFileName, scanFileName){
             sh "${builderPath} scan --server-id=repo21 '${scanFileName}' --ant=true --watches ${watchName}"
             statusMatrix[repoName]["Scan"] = '✅'
         }catch(e){
-            echo "Inside Scan Binary Catch"
+            // Scan violations on dev binaries are recorded but not fatal — the job should
+            // not be blocked by CVEs that need fixing in the upstream projects.
             statusMatrix[repoName]["Scan"] = '❌'
-            throw e
+            echo "Scan violations found for ${repoName}: ${e.message}"
         }
     }
 }
@@ -480,18 +481,27 @@ def executeGradle(repoName, details){
         echo "Contents Inside.."
         sh "pwd"
         sh "ls -la"
-        
-        // jf gradle requires a per-project .jfrog/projects/gradle.yaml. Always run gradlec
-        // here so `jf gradle ... --use-wrapper` can resolve through repo21.
-        sh "${builderPath} gradlec --server-id-resolve=repo21 --repo-resolve=dev-master-maven-virtual --use-wrapper"
-        
+
+        // build-info-extractor and artifactory-client-java both declare com.jfrog.artifactory
+        // in their own buildscript{} block. jf gradle injects a different version of the same
+        // plugin as an init-script dependency, producing a classloader conflict. Use the
+        // project's own Gradle wrapper for these two so only one version is ever loaded.
+        def useRawGradlew = repoName in ['build-info-extractor', 'artifactory-client-java']
+
+        if (!useRawGradlew) {
+            // jf gradle requires a per-project .jfrog/projects/gradle.yaml. Always run gradlec
+            // here so `jf gradle ... --use-wrapper` can resolve through repo21.
+            sh "${builderPath} gradlec --server-id-resolve=repo21 --repo-resolve=dev-master-maven-virtual --use-wrapper"
+        }
+
         echo "Starting Gradle build for ${repoName}..."
 
+        def gradleCmd = useRawGradlew ? "./gradlew" : "${builderPath} gradle"
         def hasFunctionalTest = details.hasFunctionalTest
         if (hasFunctionalTest) {
             echo "Project has a 'functionalTest' task. Excluding it."
             try{
-                sh "${builderPath} gradle clean build -x test -x functionalTest"
+                sh "${gradleCmd} clean build -x test -x functionalTest"
                 statusMatrix[repoName]["Build"] = '✅'
             }catch (e) {
                 statusMatrix[repoName]["Build"] = '❌'
@@ -503,7 +513,7 @@ def executeGradle(repoName, details){
         } else {
             echo "Project does not have a 'functionalTest' task."
             try{
-                sh "${builderPath} gradle clean build -x test"
+                sh "${gradleCmd} clean build -x test"
                 statusMatrix[repoName]["Build"] = '✅'
             }catch (e) {
                 statusMatrix[repoName]["Build"] = '❌'


### PR DESCRIPTION
## Summary

The \`ecosystem-build-and-scan-dev-binaries-for-plugins\` job was failing builds for 9 out of 12 plugins. This PR fixes the root causes:

- **Route vendor plugins through ecosys project virtual repos** — bamboo, Jenkins, and TeamCity plugins need vendor-specific SDK artifacts (Atlassian SDK, Jenkins BOM, TeamCity agent API) that are absent from \`dev-master-maven-virtual\`. Added a \`resolveRepo\` field to each affected entry in \`reposMap\` and updated \`executeMaven()\` to use it (falling back to \`dev-master-maven-virtual\` for standard Maven plugins):
  - \`bamboo-artifactory-plugin\`, \`bamboo-jfrog-plugin\` → \`ecosys-bamboo-repos\`
  - \`artifactory-jenkins-plugin\`, \`jenkins-jfrog-plugin\` → \`ecosys-jenkins-repos\`
  - \`teamcity-artifactory-plugin\` → \`ecosys-teamcity-repos\`

- **Fix Gradle classloader conflict** — \`build-info-extractor\` and \`artifactory-client-java\` both declare \`com.jfrog.artifactory\` in their own \`buildscript {}\`. \`jf gradle\` injects a different version of the same plugin via init script, causing \`Cannot cast ArtifactoryPluginConvention to ArtifactoryPluginConvention\`. Switched these projects to use \`./gradlew\` directly for the build step.

- **Fix Java version mismatch for \`jfrog-testing-infra\`** — \`jf gradle\` injects \`build-info-extractor-gradle-4.35.9-uber.jar\` compiled with Java 17 (class file major version 61), but \`jfrog-testing-infra\` runs with JDK 8. Switched to \`./gradlew\` for the build step.

- **Always run \`jf gradlec\` before the build** — even for projects using \`./gradlew\`, so \`jf audit\` has a valid \`gradle.yaml\` pointing at \`repo21\`. Without this, \`jfrog-testing-infra\`'s own \`gradle.yaml\` (with \`serverID: internal\`) caused \`jf audit\` to fail.

- **Make Xray scan violations non-fatal** — CVE violations in dev binaries are recorded as ❌ in the status matrix but no longer throw, so the job is not blocked by upstream dependency vulnerabilities that need fixing in the individual projects.

## Test plan

- [x] Triggered \`ecosystem-build-and-scan-dev-binaries-for-plugins\` against this branch — 10/12 plugins now build and upload successfully (up from 3/12 on \`main\`)
- [x] \`ecosys-bamboo-repos\`, \`ecosys-jenkins-repos\`, \`ecosys-teamcity-repos\` confirmed active in build logs
- [x] \`build-info-extractor\`, \`artifactory-client-java\`, \`jfrog-testing-infra\` build with \`./gradlew\` — no classloader or Java version errors
- [x] Scan violations on \`artifactory-gradle-plugin\`, \`jfrog-azure-devops-extension\` recorded as ❌ but job continues
- [ ] \`bamboo-jfrog-plugin\` still fails (403 on \`netty-codec-http:4.1.112.Final\` blocked by Xray policy — requires dependency upgrade in the plugin itself, not a pipeline issue)